### PR TITLE
Resolved issues in DebugDraw2D

### DIFF
--- a/addons/debugdraw2d/DebugDraw2D.gd
+++ b/addons/debugdraw2d/DebugDraw2D.gd
@@ -87,8 +87,8 @@ func _process_primitives(primitives, delta):
 		if primitive.duration_left < 0:
 			indices_to_remove.push_back(i)
 		primitive.duration_left -= delta
-	for i in indices_to_remove:
-		primitives.remove_at(i)
+	for i in range(indices_to_remove.size() - 1, -1, -1):
+		primitives.remove_at(indices_to_remove[i])
 
 func _draw():
 	_draw_primitives(rects)


### PR DESCRIPTION
Fixed an error in the script causing the remove_at function to delete items at indices that don't exist. This was causing errors to be thrown in the console regularly.

Also resolved an error where the remove_at was trying to remove the index of the remove for loop, rather than from the actual remove indices array. This was causing random drawn objects to be deleted rather than their intended target.